### PR TITLE
Add AES-GCM encryption utilities

### DIFF
--- a/eden/__init__.py
+++ b/eden/__init__.py
@@ -1,0 +1,1 @@
+# Eden package

--- a/eden/encryption/encryptor.py
+++ b/eden/encryption/encryptor.py
@@ -1,1 +1,34 @@
-# Encryption utilities
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+import os
+
+# AES-GCM parameters
+NONCE_SIZE = 12
+KEY_SIZE = 32
+
+
+def generate_key(size: int = KEY_SIZE) -> bytes:
+    """Return a new random key of ``size`` bytes."""
+    return AESGCM.generate_key(bit_length=size * 8)
+
+
+def generate_nonce(size: int = NONCE_SIZE) -> bytes:
+    """Return a secure random nonce."""
+    return os.urandom(size)
+
+
+def encrypt(data: bytes, key: bytes) -> bytes:
+    """Encrypt ``data`` with ``key`` and return ``nonce`` + ciphertext."""
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    aesgcm = AESGCM(key)
+    nonce = generate_nonce()
+    ciphertext = aesgcm.encrypt(nonce, data, None)
+    return nonce + ciphertext
+
+
+def decrypt(blob: bytes, key: bytes) -> bytes:
+    """Decrypt a blob produced by :func:`encrypt`."""
+    nonce = blob[:NONCE_SIZE]
+    ciphertext = blob[NONCE_SIZE:]
+    aesgcm = AESGCM(key)
+    return aesgcm.decrypt(nonce, ciphertext, None)

--- a/eden/requirements.txt
+++ b/eden/requirements.txt
@@ -1,1 +1,2 @@
 PyQt5
+cryptography

--- a/eden/tests/test_encryptor.py
+++ b/eden/tests/test_encryptor.py
@@ -1,1 +1,23 @@
-# Test for encryptor
+import os
+import sys
+import pytest
+
+# Ensure the repository root is on the path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from eden.encryption import encryptor
+
+
+def test_encrypt_decrypt_roundtrip():
+    key = encryptor.generate_key()
+    data = b"secret message"
+    blob = encryptor.encrypt(data, key)
+    assert data == encryptor.decrypt(blob, key)
+
+
+def test_unique_keys():
+    k1 = encryptor.generate_key()
+    k2 = encryptor.generate_key()
+    assert k1 != k2
+    assert len(k1) == encryptor.KEY_SIZE
+    assert len(k2) == encryptor.KEY_SIZE


### PR DESCRIPTION
## Summary
- implement AES-GCM helper functions in `encryptor.py`
- expose a simple `__init__` to make `eden` importable
- add cryptography dependency
- write tests for encryption helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d0f46f14832680d05280dbb58de3