### PR TITLE
Add Whisper transcription and diarization

### DIFF
--- a/eden/diarization/diarizer.py
+++ b/eden/diarization/diarizer.py
@@ -1,1 +1,38 @@
-# Speaker diarization
+"""Speaker diarization utilities using pyannote.audio."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import List, Dict
+
+
+def _load_pipeline(model: str):
+    """Load a pyannote.audio Pipeline for diarization."""
+    try:
+        pyannote = import_module("pyannote.audio")
+    except Exception as exc:  # pragma: no cover - executed only when missing
+        raise ImportError("pyannote.audio is required for speaker diarization") from exc
+    Pipeline = pyannote.Pipeline
+    return Pipeline.from_pretrained(model)
+
+
+class SpeakerDiarizer:
+    """Wrapper around :mod:`pyannote.audio` for diarization."""
+
+    def __init__(self, model: str = "pyannote/speaker-diarization") -> None:
+        self.pipeline = _load_pipeline(model)
+
+    def diarize(self, audio_path: str) -> List[Dict]:
+        """Return diarization segments for ``audio_path``."""
+        diarization = self.pipeline(audio_path)
+        segments: List[Dict] = []
+        for turn, _, speaker in diarization.itertracks(yield_label=True):
+            segments.append(
+                {
+                    "start": float(turn.start),
+                    "end": float(turn.end),
+                    "speaker": speaker,
+                }
+            )
+        return segments
+

--- a/eden/requirements.txt
+++ b/eden/requirements.txt
@@ -1,1 +1,3 @@
 PyQt5
+openai-whisper
+pyannote.audio

--- a/eden/tests/test_diarizer.py
+++ b/eden/tests/test_diarizer.py
@@ -1,1 +1,22 @@
-# Test for diarizer
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from eden.diarization import diarizer
+
+
+class FakePipeline:
+    def __call__(self, path):
+        class Dummy:
+            def itertracks(self, yield_label=True):
+                yield types.SimpleNamespace(start=0.0, end=1.0), None, "A"
+        return Dummy()
+
+
+def test_diarize(monkeypatch):
+    monkeypatch.setattr(diarizer, "_load_pipeline", lambda model: FakePipeline())
+    d = diarizer.SpeakerDiarizer()
+    result = d.diarize("dummy.wav")
+    assert result == [{"start": 0.0, "end": 1.0, "speaker": "A"}]

--- a/eden/tests/test_transcriber.py
+++ b/eden/tests/test_transcriber.py
@@ -1,1 +1,35 @@
-# Test for transcriber
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from eden.transcription import transcriber
+from eden.diarization import diarizer
+
+
+class FakeWhisperModel:
+    def transcribe(self, path):
+        return {"segments": [{"start": 0.0, "end": 1.0, "text": "hello"}]}
+
+
+class FakePipeline:
+    def __call__(self, path):
+        class Dummy:
+            def itertracks(self, yield_label=True):
+                yield types.SimpleNamespace(start=0.0, end=1.0), None, "A"
+        return Dummy()
+
+
+def test_transcribe(monkeypatch):
+    monkeypatch.setattr(transcriber, "_load_model", lambda name: FakeWhisperModel())
+    segments = transcriber.transcribe("dummy.wav")
+    assert segments == [{"start": 0.0, "end": 1.0, "text": "hello"}]
+
+
+def test_transcribe_with_diarization(monkeypatch):
+    monkeypatch.setattr(transcriber, "_load_model", lambda name: FakeWhisperModel())
+    monkeypatch.setattr(diarizer, "_load_pipeline", lambda model: FakePipeline())
+    d = diarizer.SpeakerDiarizer()
+    result = transcriber.transcribe_with_diarization("dummy.wav", diarizer=d)
+    assert result == [{"speaker": "A", "start": 0.0, "end": 1.0, "text": "hello"}]

--- a/eden/transcription/transcriber.py
+++ b/eden/transcription/transcriber.py
@@ -1,1 +1,92 @@
-# Transcription logic
+"""Utilities for transcribing audio files using Whisper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import List, Dict, Optional
+
+from ..diarization.diarizer import SpeakerDiarizer
+
+
+def _load_model(name: str):
+    """Load a Whisper model by name."""
+    try:
+        whisper = import_module("whisper")
+    except Exception as exc:  # pragma: no cover - executed only when missing
+        raise ImportError("Whisper library is required for transcription") from exc
+    return whisper.load_model(name)
+
+
+@dataclass
+class TranscriptSegment:
+    start: float
+    end: float
+    text: str
+    speaker: Optional[str] | None = None
+
+
+def transcribe(audio_path: str, model_name: str = "base") -> List[Dict]:
+    """Transcribe an audio file using the Whisper library.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the audio file to transcribe.
+    model_name:
+        Whisper model name. Defaults to ``"base"``.
+
+    Returns
+    -------
+    List of dictionaries containing ``start``, ``end`` and ``text`` keys.
+    """
+    model = _load_model(model_name)
+    result = model.transcribe(audio_path)
+    segments: List[Dict] = []
+    for segment in result.get("segments", []):
+        segments.append(
+            {
+                "start": float(segment["start"]),
+                "end": float(segment["end"]),
+                "text": segment["text"].strip(),
+            }
+        )
+    return segments
+
+
+def transcribe_with_diarization(
+    audio_path: str,
+    model_name: str = "base",
+    diarizer: Optional[SpeakerDiarizer] = None,
+) -> List[Dict]:
+    """Transcribe ``audio_path`` and annotate speaker labels.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the audio file.
+    model_name:
+        Whisper model name to use.
+    diarizer:
+        Optional :class:`~eden.diarization.diarizer.SpeakerDiarizer` instance. If
+        not provided, a default one is created.
+
+    Returns
+    -------
+    List of dictionaries with ``speaker``, ``start``, ``end`` and ``text`` keys.
+    """
+    diarizer = diarizer or SpeakerDiarizer()
+    transcript_segments = transcribe(audio_path, model_name)
+    speaker_segments = diarizer.diarize(audio_path)
+
+    labelled: List[Dict] = []
+    for seg in transcript_segments:
+        midpoint = (seg["start"] + seg["end"]) / 2
+        speaker = None
+        for diar in speaker_segments:
+            if diar["start"] <= midpoint <= diar["end"]:
+                speaker = diar["speaker"]
+                break
+        labelled.append({"speaker": speaker, **seg})
+    return labelled
+


### PR DESCRIPTION
## Summary
- implement Whisper-based transcription utilities
- add pyannote-based speaker diarization logic
- generate speaker-labelled transcripts
- add unit tests for new functionality
- update requirements with new dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d0f583348326a1352e64a112cdd7