### PR TITLE
Add regex-based PII redactor

### DIFF
--- a/eden/redaction/redactor.py
+++ b/eden/redaction/redactor.py
@@ -1,1 +1,59 @@
-# Content redaction
+"""Utilities for redacting Personally Identifiable Information (PII)."""
+
+from __future__ import annotations
+
+import re
+
+
+class Redactor:
+    """Redact PII such as names, phone numbers and addresses.
+
+    The implementation is intentionally simple and relies solely on regular
+    expressions.  It is not meant to be exhaustive but rather to provide a
+    lightweight solution for unit tests and examples.
+    """
+
+    #: Regex matching ``First Last`` style names.  This obviously does not cover
+    #: every possible name but works well enough for short demonstrations.
+    NAME_PATTERN = re.compile(r"\b[A-Z][a-z]+\s+[A-Z][a-z]+\b(?!\s+[A-Z])")
+
+    #: Regex for common US phone number formats such as ``123-456-7890`` or
+    #: ``(123) 456 7890``.
+    PHONE_PATTERN = re.compile(
+        r"(?:\+?\d{1,2}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"
+    )
+
+    #: Very small address detector that looks for a street number followed by a
+    #: street name and type (e.g. ``Main Street``).  It supports a handful of
+    #: common street types and is case-insensitive.
+    ADDRESS_PATTERN = re.compile(
+        r"\b\d{1,5}\s+(?:[A-Za-z0-9]+\s+)*(?:Street|St|Road|Rd|Avenue|Ave|"
+        r"Boulevard|Blvd|Lane|Ln|Drive|Dr|Court|Ct)\b",
+        re.IGNORECASE,
+    )
+
+    #: Text that replaces any detected PII
+    REPLACEMENT = "[REDACTED]"
+
+    def redact(self, text: str) -> str:
+        """Return ``text`` with any recognised PII replaced."""
+
+        patterns = [
+            # Order matters: redact addresses before names so that street names
+            # do not get replaced individually.
+            self.ADDRESS_PATTERN,
+            self.NAME_PATTERN,
+            self.PHONE_PATTERN,
+        ]
+
+        redacted = text
+        for pattern in patterns:
+            redacted = pattern.sub(self.REPLACEMENT, redacted)
+        return redacted
+
+
+def redact_pii(text: str) -> str:
+    """Convenience function that uses :class:`Redactor`."""
+
+    return Redactor().redact(text)
+

--- a/eden/tests/test_redactor.py
+++ b/eden/tests/test_redactor.py
@@ -1,1 +1,36 @@
-# Test for redactor
+"""Tests for the :mod:`eden.redaction.redactor` module."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure the project root is on ``sys.path`` when tests are executed directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from eden.redaction.redactor import Redactor, redact_pii
+
+
+def test_redacts_names():
+    text = "Alice Smith met Bob Jones yesterday."
+    expected = "[REDACTED] met [REDACTED] yesterday."
+    assert redact_pii(text) == expected
+
+
+def test_redacts_phone_numbers():
+    text = "Call me at 555-123-4567 tomorrow."
+    expected = "Call me at [REDACTED] tomorrow."
+    assert redact_pii(text) == expected
+
+
+def test_redacts_addresses():
+    text = "He lives at 123 Main Street near the park."
+    expected = "He lives at [REDACTED] near the park."
+    assert redact_pii(text) == expected
+
+
+def test_redactor_class_equivalent():
+    r = Redactor()
+    text = "Contact Jane Doe at (123) 456-7890, 42 Oak Road."
+    expected = "Contact [REDACTED] at [REDACTED], [REDACTED]."
+    assert r.redact(text) == expected


### PR DESCRIPTION
## Summary
- implement simple PII redactor that strips names, phone numbers and addresses
- add unit tests for the redactor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d0f6650c8326aba76d03ffcb5d7b