### PR TITLE
Improve docs and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Eden
-Production build.
+
+Minimal prototype of the Eden voice recorder application.
+
+## Setup
+
+This project requires **Python 3.8+**. Install the Python dependencies using
+```
+pip install -r eden/requirements.txt
+```
+
+## Running the application
+
+Launch the GUI with
+```
+python -m eden.app
+```
+which will open the simple PyQt5 window.
+
+## Running tests
+
+Unit tests are written with `pytest`. Execute them with
+```
+pytest
+```

--- a/eden/README.md
+++ b/eden/README.md
@@ -1,1 +1,17 @@
-# Eden\n\nHigh-end voice recorder app with PyQt5.
+# Eden
+
+High-end voice recorder app with PyQt5.
+
+## Setup and usage
+
+Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+Run the application:
+
+```
+python -m eden.app
+```

--- a/eden/__init__.py
+++ b/eden/__init__.py
@@ -1,0 +1,1 @@
+"""Eden package"""

--- a/eden/diarization/diarizer.py
+++ b/eden/diarization/diarizer.py
@@ -1,1 +1,10 @@
-# Speaker diarization
+"""Toy implementation of a diarizer."""
+
+from typing import List, Dict
+
+
+def diarize(audio_data: str) -> List[Dict[str, int]]:
+    """Return a single speaker block for ``audio_data``."""
+
+    return [{"speaker": "speaker1", "start": 0, "end": len(audio_data)}]
+

--- a/eden/encryption/encryptor.py
+++ b/eden/encryption/encryptor.py
@@ -1,1 +1,14 @@
-# Encryption utilities
+"""Very small symmetric XOR based encryption utilities."""
+
+
+def encrypt(data: str, key: int) -> str:
+    """Encrypt ``data`` with a simple XOR cipher."""
+
+    return "".join(chr(ord(c) ^ key) for c in data)
+
+
+def decrypt(data: str, key: int) -> str:
+    """Decrypt XOR encrypted ``data``."""
+
+    return encrypt(data, key)
+

--- a/eden/recorder/capture.py
+++ b/eden/recorder/capture.py
@@ -1,1 +1,18 @@
-# Audio capture logic
+"""Simple audio capture stubs used for testing."""
+
+def capture_audio(device: str) -> str:
+    """Pretend to capture audio from the provided device.
+
+    Parameters
+    ----------
+    device:
+        Name of the input device.
+
+    Returns
+    -------
+    str
+        Message indicating where audio was captured from.
+    """
+
+    return f"captured from {device}"
+

--- a/eden/redaction/redactor.py
+++ b/eden/redaction/redactor.py
@@ -1,1 +1,13 @@
-# Content redaction
+"""Simple text redaction utilities."""
+
+from typing import Iterable
+
+
+def redact(text: str, phrases: Iterable[str]) -> str:
+    """Replace occurrences of ``phrases`` in ``text`` with ``[REDACTED]``."""
+
+    result = text
+    for ph in phrases:
+        result = result.replace(ph, "[REDACTED]")
+    return result
+

--- a/eden/tests/__init__.py
+++ b/eden/tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+# Ensure the project root is on sys.path so tests can import the package
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/eden/tests/test_capture.py
+++ b/eden/tests/test_capture.py
@@ -1,1 +1,8 @@
-# Test for capture
+"""Tests for recorder.capture module."""
+
+from eden.recorder.capture import capture_audio
+
+
+def test_capture_audio():
+    assert capture_audio("mic1") == "captured from mic1"
+

--- a/eden/tests/test_diarizer.py
+++ b/eden/tests/test_diarizer.py
@@ -1,1 +1,9 @@
-# Test for diarizer
+"""Tests for diarization.diarizer module."""
+
+from eden.diarization.diarizer import diarize
+
+
+def test_diarize_returns_single_block():
+    blocks = diarize("hello")
+    assert blocks == [{"speaker": "speaker1", "start": 0, "end": 5}]
+

--- a/eden/tests/test_encryptor.py
+++ b/eden/tests/test_encryptor.py
@@ -1,1 +1,12 @@
-# Test for encryptor
+"""Tests for encryption.encryptor module."""
+
+from eden.encryption.encryptor import encrypt, decrypt
+
+
+def test_encrypt_decrypt_cycle():
+    message = "secret"
+    key = 42
+    cipher = encrypt(message, key)
+    assert cipher != message
+    assert decrypt(cipher, key) == message
+

--- a/eden/tests/test_matcher.py
+++ b/eden/tests/test_matcher.py
@@ -1,1 +1,9 @@
-# Test for matcher
+"""Tests for voiceprints.matcher module."""
+
+from eden.voiceprints.matcher import match_voiceprint
+
+
+def test_match_voiceprint_finds_best_match():
+    db = [("alice", "vp1"), ("bob", "vp2")]
+    assert match_voiceprint("vp2", db) == "bob"
+

--- a/eden/tests/test_redactor.py
+++ b/eden/tests/test_redactor.py
@@ -1,1 +1,10 @@
-# Test for redactor
+"""Tests for redaction.redactor module."""
+
+from eden.redaction.redactor import redact
+
+
+def test_redact_replaces_phrases():
+    text = "this is top secret material"
+    result = redact(text, ["top secret"])
+    assert "[REDACTED]" in result
+

--- a/eden/tests/test_transcriber.py
+++ b/eden/tests/test_transcriber.py
@@ -1,1 +1,8 @@
-# Test for transcriber
+"""Tests for transcription.transcriber module."""
+
+from eden.transcription.transcriber import transcribe
+
+
+def test_transcribe_strips_whitespace():
+    assert transcribe("  HELLO   WORLD  ") == "HELLO WORLD"
+

--- a/eden/transcription/transcriber.py
+++ b/eden/transcription/transcriber.py
@@ -1,1 +1,8 @@
-# Transcription logic
+"""Utility helpers for converting audio to text."""
+
+
+def transcribe(audio_data: str) -> str:
+    """Dummy implementation returning cleaned text for tests."""
+
+    return " ".join(audio_data.strip().split())
+

--- a/eden/utils/helpers.py
+++ b/eden/utils/helpers.py
@@ -1,1 +1,7 @@
-# Helper functions
+"""Miscellaneous helper utilities."""
+
+def normalize_text(text: str) -> str:
+    """Return the text in lowercase with whitespace collapsed."""
+
+    return " ".join(text.lower().split())
+

--- a/eden/utils/logger.py
+++ b/eden/utils/logger.py
@@ -1,1 +1,17 @@
-# Logger setup
+"""Utility for obtaining a configured logger."""
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a simple console logger with ``INFO`` level."""
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter('[%(asctime)s] %(levelname)s - %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+

--- a/eden/voiceprints/matcher.py
+++ b/eden/voiceprints/matcher.py
@@ -1,1 +1,13 @@
-# Voiceprint matching
+"""Very small voiceprint matcher for demonstration."""
+
+from typing import Iterable, Tuple, Optional
+
+
+def match_voiceprint(voiceprint: str, database: Iterable[Tuple[str, str]]) -> Optional[str]:
+    """Return the name from ``database`` whose voiceprint exactly matches."""
+
+    for name, vp in database:
+        if vp == voiceprint:
+            return name
+    return None
+


### PR DESCRIPTION
## Summary
- document how to install requirements, run the GUI and run tests
- provide quick setup instructions inside `eden/README.md`
- implement small helper functions in each module
- create new unit tests verifying each helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d0f87bf08326a4480dc6d7927266