### PR TITLE
Enhance redaction utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/eden/redaction/redactor.py
+++ b/eden/redaction/redactor.py
@@ -1,13 +1,32 @@
 """Simple text redaction utilities."""
 
 from typing import Iterable
+import re
 
 
-def redact(text: str, phrases: Iterable[str]) -> str:
-    """Replace occurrences of ``phrases`` in ``text`` with ``[REDACTED]``."""
+def redact(text: str, phrases: Iterable[str], ignore_case: bool = True) -> str:
+    """Replace occurrences of ``phrases`` in ``text`` with ``[REDACTED]``.
 
+    Parameters
+    ----------
+    text:
+        Original string in which to perform redaction.
+    phrases:
+        Iterable of phrases that should be replaced.
+    ignore_case:
+        If ``True`` (default), matches are done case-insensitively.
+
+    Returns
+    -------
+    str
+        A new string with all occurrences of the provided phrases replaced by
+        ``"[REDACTED]"``.
+    """
+
+    flags = re.IGNORECASE if ignore_case else 0
     result = text
     for ph in phrases:
-        result = result.replace(ph, "[REDACTED]")
+        pattern = re.compile(re.escape(ph), flags)
+        result = pattern.sub("[REDACTED]", result)
     return result
 

--- a/eden/tests/test_redactor.py
+++ b/eden/tests/test_redactor.py
@@ -3,8 +3,20 @@
 from eden.redaction.redactor import redact
 
 
-def test_redact_replaces_phrases():
-    text = "this is top secret material"
+def test_redact_replaces_phrases_case_insensitive():
+    text = "This is Top Secret material"
     result = redact(text, ["top secret"])
-    assert "[REDACTED]" in result
+    assert result == "This is [REDACTED] material"
+
+
+def test_redact_multiple_occurrences():
+    text = "secret SECRET Secret"
+    result = redact(text, ["secret"])
+    assert result == "[REDACTED] [REDACTED] [REDACTED]"
+
+
+def test_redact_when_no_phrase_found():
+    text = "nothing to redact here"
+    result = redact(text, ["classified"])
+    assert result == text
 


### PR DESCRIPTION
## Summary
- ignore case when redacting text
- cover more scenarios with unit tests
- add a basic `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d8edc448832699ebfee50808ab36